### PR TITLE
Details bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+DiyorMarketApi/DiyorMarket/appsettings.json

--- a/DiyorMarket.MVC/Lesson11/Constants/Configurations.cs
+++ b/DiyorMarket.MVC/Lesson11/Constants/Configurations.cs
@@ -1,0 +1,7 @@
+﻿namespace Lesson11.Constants
+{
+    public static class Configurations
+    {
+        public const string JwtToken = "JwtToken";
+    }
+}

--- a/DiyorMarket.MVC/Lesson11/Controllers/AuthController.cs
+++ b/DiyorMarket.MVC/Lesson11/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
-﻿using Lesson11.Models;
+﻿using Lesson11.Constants;
+using Lesson11.Models;
 using Lesson11.Stores.User;
 using Lesson11.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -15,7 +16,7 @@ namespace Lesson11.Controllers
 
         public IActionResult Index()
         {
-            if (HttpContext.Request.Cookies.TryGetValue("JwtToken", out _))
+            if (HttpContext.Request.Cookies.TryGetValue(Configurations.JwtToken, out _))
             {
                 return RedirectToAction("Index", "Dashboard");
             }
@@ -41,7 +42,7 @@ namespace Lesson11.Controllers
 
             if (success)
             {
-                HttpContext.Response.Cookies.Append("JwtToken", token, new CookieOptions
+                HttpContext.Response.Cookies.Append(Configurations.JwtToken, token, new CookieOptions
                 {
                     Secure = true,
                     SameSite = SameSiteMode.Strict,

--- a/DiyorMarket.MVC/Lesson11/Services/ApiClient.cs
+++ b/DiyorMarket.MVC/Lesson11/Services/ApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Lesson11.Exceptions;
+﻿using Lesson11.Constants;
+using Lesson11.Exceptions;
 
 namespace Lesson11.Services
 {
@@ -19,7 +20,7 @@ namespace Lesson11.Services
         {
             string token = string.Empty;
             var request = new HttpRequestMessage(HttpMethod.Get, _client.BaseAddress?.AbsolutePath + "/" + url);
-            _contextAccessor.HttpContext?.Request.Cookies.TryGetValue("JwtToken", out token);
+            _contextAccessor.HttpContext?.Request.Cookies.TryGetValue(Configurations.JwtToken, out token);
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
 
             var response = _client.Send(request);

--- a/DiyorMarket.MVC/Lesson11/Views/Customers/Details.cshtml
+++ b/DiyorMarket.MVC/Lesson11/Views/Customers/Details.cshtml
@@ -6,7 +6,16 @@
 
 <nav>
     <div class="nav nav-tabs" id="nav-tab" role="tablist">
-        <button class="nav-link active" id="nav-details-tab" data-bs-toggle="tab" data-bs-target="#nav-details" type="button" role="tab" aria-controls="nav-details" aria-selected="true">Details</button>
+        <button class="nav-link active"
+                id="nav-details-tab" 
+                data-bs-toggle="tab"
+                data-bs-target="#nav-details"
+                type="button"
+                role="tab"
+                aria-controls="nav-details"
+                aria-selected="true">
+                    Details
+        </button>
         <button class="nav-link" id="nav-history-tab" data-bs-toggle="tab" data-bs-target="#nav-history" type="button" role="tab" aria-controls="nav-history" aria-selected="false">History</button>
     </div>
 </nav>
@@ -33,23 +42,17 @@
             @Html.DisplayFor(model => model.PhoneNumber)
         </dd>
         <div class="mt-4">
-            <a asp-action="Delete" asp-route-id="@Model?.Id" class="btn btn-outline-danger">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
-                    <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5M8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5m3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0" />
-                </svg>
-                Delete
+            <a asp-action="Index" class="btn btn-outline-info">
+                <i class="fa-solid fa-arrow-left"></i>
+                Back
             </a>
-            <a asp-action="Edit" asp-route-id="@Model?.Id" class="btn btn-outline-success">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-fill" viewBox="0 0 16 16">
-                    <path d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793 14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708zm.646 6.061L9.793 2.5 3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.5.5 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11z" />
-                </svg>
+            <a asp-action="Edit" asp-route-id="@Model?.Id" class="btn btn-outline-warning">
+                <i class="fa-solid fa-pen"></i>
                 Edit
             </a>
-            <a asp-action="Index" class="btn btn-outline-info">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left-circle-fill" viewBox="0 0 16 16">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0m3.5 7.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5z" />
-                </svg>
-                Back to List
+            <a asp-action="Delete" asp-route-id="@Model?.Id" class="btn btn-outline-danger">
+                <i class="fa-solid fa-trash"></i>
+                Delete
             </a>
         </div>
     </dl>

--- a/DiyorMarket.MVC/Lesson11/Views/Customers/Index.cshtml
+++ b/DiyorMarket.MVC/Lesson11/Views/Customers/Index.cshtml
@@ -79,7 +79,7 @@
 
     <script id="template" type="text/x-template">
         <div>
-            <a rel='nofollow' href="customers/Details/${Id}">${Id}</a>
+            <a rel='nofollow' href="Customers/Details?id=${Id}">${Id}</a>
         </div>
     </script>
 </div>


### PR DESCRIPTION
1. When opening details from index page, details action was triggered twice because of usage following link "customers/details/{id}". For fixing this use "customers/details?id={id}"
2. Use single icon source for project.
3. For constants like "JwtToken" use configuration instead of hard-coded values.